### PR TITLE
Bundle GitBook MCP server in the Claude Code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,5 +8,11 @@
   },
   "homepage": "https://gitbook.com",
   "repository": "https://github.com/GitbookIO/gitbook-skills",
-  "license": "MIT"
+  "license": "MIT",
+  "mcpServers": {
+    "gitbook": {
+      "type": "http",
+      "url": "https://mcp.gitbook.com/mcp"
+    }
+  }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -15,6 +15,7 @@
     "markdown"
   ],
   "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "GitBook",
     "shortDescription": "Build and edit GitBook docs in Codex.",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "gitbook": {
+      "url": "https://mcp.gitbook.com/mcp"
+    }
+  }
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "gitbook": {
+      "url": "https://mcp.gitbook.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
One install now delivers skills + MCP server together:
  claude plugin marketplace add GitbookIO/gitbook-skills
  claude plugin install gitbook@gitbook-skills
Plugin MCP servers activate via /reload-plugins — no session restart, unlike claude mcp add. OAuth still completes lazily via /mcp.