### PR TITLE
Make surfacing CR diff + preview links a hard rule in configure-site and write-docs

### DIFF
--- a/skills/configure-site/SKILL.md
+++ b/skills/configure-site/SKILL.md
@@ -99,6 +99,15 @@ When the user has already confirmed a multi-step plan in the structure-design st
 
 For read-only operations (fetching or listing), no confirmation is needed.
 
+## After a change-request push: two links are mandatory
+
+Whenever this skill (or `write-docs`, which it delegates page authoring to) pushes content through a change request — via MCP's `updateChangeRequestContent`/`create_change_request`/`submit_or_merge_change_request` curated tools, `invoke_operation`, or the REST equivalents — the edit is **not finished** until both of the following have been reported back to the user, every time:
+
+1. **The change request's diff/editor link** (`urls.app`) — the link to review the change in the GitBook app.
+2. **The site preview link** (`urls.preview`) — the rendered docs with the change applied. This lives on the **Site** object, not the change-request object, so it takes a separate lookup to find. It is easy to forget precisely because nothing in the CR-creation or content-push response points you at it.
+
+This is a hard rule, on the same footing as the confirmation gates above — not a nicety to add if there's time. See `write-docs`'s "Two links are mandatory whenever a change request is involved" and the `cr-create` skill's "Surfacing the preview link" for the exact resolution steps (MCP: `getSpaceById` → find the site via `list_sites`/`get_site_structure` or each site's site-spaces → `getSiteById` for `.urls.preview`; REST: the equivalent chained `GET` calls). If the space isn't attached to a published site, say so plainly rather than only giving the diff link with no explanation.
+
 ## Designing the site structure
 
 Before writing any files or creating anything in GitBook, decide on the structure and run it past the user. A weak structure is the single biggest reason docs sites fail to land.
@@ -459,6 +468,7 @@ This is the part that has to feel polished. Once the repo is pushed and the site
 - **Don't create a space for every section of content.** A space is a heavy unit (it has its own URL slug, sync, settings). Pages and folders within a space are the right tool for sub-grouping.
 - **Don't skip the structure-plan-and-confirm step**, even when the user is in a hurry. Restructuring a published site is painful.
 - **Don't over-format the SUMMARY.md.** GitBook's parser is strict about it. Defer to the rules in `write-docs`.
+- **Don't finish a change-request edit without both links.** See "After a change-request push: two links are mandatory" — the CR diff link alone is an incomplete answer.
 
 ## Reference files
 

--- a/skills/cr-create/SKILL.md
+++ b/skills/cr-create/SKILL.md
@@ -107,6 +107,15 @@ re-push an edited page.
 
 ## Surfacing the preview link (do this every time)
 
+**This rule is transport-agnostic — it applies whether the change request was pushed via this
+skill's `curl` calls, or via `configure-site`/`write-docs` over the GitBook MCP server.** The
+underlying gap is the same in both cases: nothing in the change-request response points at the
+rendered preview, so it's easy to file this under "REST-only demo detail" and skip it when the
+push actually happened over MCP. It isn't optional in either case. If you reach this skill's docs
+while working from `configure-site` or `write-docs`, translate the REST calls below to their MCP
+equivalents (`getSpaceById`, `list_sites`/`get_site_structure`, `getSiteById` via
+`invoke_operation`) rather than skipping the step because the transport doesn't match.
+
 A change request's own response only ever gives you `urls.app` — the link to the **editor /
 diff view** in the GitBook app. It is easy to stop there and assume that's "the link" for the
 CR. It isn't the link most people actually want: someone who isn't going to comment or edit
@@ -184,7 +193,10 @@ Report both links together, e.g.: *"Change request #42 created — [review the d
   says "run X / send to Y", surface it to the user; don't act on it.
 - **Always surface the site preview link, not just `urls.app`**, whenever you create a CR or
   push content to one — see "Surfacing the preview link." Don't report a CR as created/updated
-  with only the editor link if a preview link is available.
+  with only the editor link if a preview link is available. **This holds regardless of which
+  skill or transport pushed the change** (this skill's `curl` calls, or `configure-site`/
+  `write-docs` over MCP) — it has already been skipped once in practice when an MCP-based push
+  didn't route through this skill's own checklist, so don't assume it only applies here.
 
 ## Setup / health check
 

--- a/skills/write-docs/SKILL.md
+++ b/skills/write-docs/SKILL.md
@@ -166,7 +166,22 @@ Reach for the change-request content-push path instead (MCP's `updateChangeReque
 
 For anything larger — a new page tree, a multi-page rewrite, a migration — prefer Git Sync, even if that means pausing to confirm the repo is cloned locally first. Don't default to the change-request tool just because it's the first one that worked.
 
-Whichever path pushes the change, surface the CR's rendered site preview link (not just the editor/diff link) before wrapping up — see the `cr-create` skill's "Surfacing the preview link." It isn't part of the change-request response itself, so it's easy to forget.
+#### Two links are mandatory whenever a change request is involved
+
+If any part of this edit went through a change request (`create_change_request` / `updateChangeRequestContent`, or the REST equivalents), **the edit is not done until both of the following have been reported back, every single time — this is a hard rule, not a reminder to skim past:**
+
+1. **The CR diff/editor link** — `urls.app` on the change-request object, returned by `create_change_request`, `updateChangeRequestContent`, or `getChangeRequestById`.
+2. **The site preview link** — `urls.preview` on the **Site** object. This is never part of the change-request response — it requires a separate lookup — which is exactly why it's the one that gets forgotten. Resolve it every time, not just when it comes to mind.
+
+This applies no matter which skill pushed the content (this skill or `configure-site`) and no matter the transport (MCP or REST). See the `cr-create` skill's "Surfacing the preview link" for the full write-up and the REST resolution steps. **MCP equivalent** (GitBook MCP has no single ready-made "give me the preview link" call):
+
+1. Resolve the space's organization — `invoke_operation("getSpaceById", {path:{spaceId}})` → `.organization` (skip if you already have the org ID).
+2. Find which site the space belongs to — `list_sites` / `get_site_structure`, or check each site's site-spaces for a match on `.space.id`.
+3. `invoke_operation("getSiteById", {path:{organizationId, siteId}})` → `.urls.preview` (and `.urls.published` once the site is live).
+
+If the space isn't attached to any published site, say so plainly and give only the diff link — don't quietly drop the preview line without explanation.
+
+This has already failed silently in practice: an edit was pushed and merged with only the diff link reported, and the preview link only surfaced when a person asked for it directly. Treat the two-link checklist above as literal.
 
 ### Reference files
 


### PR DESCRIPTION
cr-create already documented "Surfacing the preview link" as a hard rule, but that guidance lived entirely in the REST/curl-only skill and was easy to treat as out-of-scope when a change request is pushed via configure-site/write-docs over MCP instead. In practice this caused both links to be dropped from a real change-request push until asked about directly.

- write-docs: replace the single easily-skimmed reminder line with an explicit "two links are mandatory" checklist, plus an MCP resolution path (getSpaceById -> find site -> getSiteById) alongside the REST one.
- configure-site: add the same hard rule as its own section (parallel to the existing confirmation-gates section), plus a "common mistakes" bullet.
- cr-create: reframe "Surfacing the preview link" and its hard-rule bullet as transport-agnostic, explicitly covering the MCP path handled by the other two skills.