### PR TITLE
Default to site-wide Git Sync instead of per-space setup

### DIFF
--- a/skills/configure-site/SKILL.md
+++ b/skills/configure-site/SKILL.md
@@ -2,7 +2,7 @@
 name: configure-site
 metadata:
   version: "1.0"
-description: "Create and maintain entire GitBook documentation sites end-to-end — design the site structure from source content, scaffold a Git repository in monorepo layout, set up the GitHub/GitLab remote, drive the GitBook API (via its REST API or MCP server) to create the site/sections/spaces, apply branded customization, and hand the user clean instructions for the one UI step (Git Sync wiring) that GitBook does not expose programmatically. Trigger this skill whenever the user wants to spin up a new GitBook docs site, restructure or extend an existing one, link spaces to a Git repo for sync, change a site's branding (logo, colors, fonts, header/footer), or programmatically manage spaces, sections, or site-spaces. This skill is the orchestration layer; for authoring the markdown content of any individual page it defers to the companion `write-docs` skill."
+description: "Create and maintain entire GitBook documentation sites end-to-end — design the site structure from source content, scaffold a Git repository in monorepo layout, set up the GitHub/GitLab remote, drive the GitBook API (via its REST API or MCP server) to create the site/sections/spaces, apply branded customization, and hand the user clean instructions for the one UI step (Git Sync wiring) that GitBook does not expose programmatically. Always set up Git Sync at the site level first — mapping every space to a directory in one repo/branch via docs.yaml — and only fall back to per-space Git Sync when one space genuinely needs an independent repo or branch. Trigger this skill whenever the user wants to spin up a new GitBook docs site, restructure or extend an existing one, link a site or spaces to a Git repo for sync, change a site's branding (logo, colors, fonts, header/footer), or programmatically manage spaces, sections, or site-spaces. This skill is the orchestration layer; for authoring the markdown content of any individual page it defers to the companion `write-docs` skill."
 ---
 
 # Configure GitBook Site
@@ -37,13 +37,15 @@ Never write the token to a file, never echo it back in a response, never commit 
 
 ## The fundamental constraint
 
-The most important thing to internalize before doing anything: **GitBook can do almost everything except set up Git Sync, regardless of transport**. Authorizing GitHub/GitLab, picking the repository, choosing the branch, setting the project directory for monorepo layouts, and choosing the initial sync direction are all UI-only operations — both the REST API and MCP (which wraps it) only let you *read* the resulting Git Sync state, never set it up.
+The most important thing to internalize before doing anything: **GitBook can do almost everything except set up Git Sync, regardless of transport**. Authorizing GitHub/GitLab, picking the repository, choosing the branch, and choosing the initial sync direction are all UI-only operations — both the REST API and MCP (which wraps it) only let you *read* the resulting Git Sync state, never set it up. There's an API operation, `installGitSyncProviderOnTarget`, that targets either a site or a space, but the account-connection (OAuth) step still has to happen in the app, and it isn't yet exposed through GitBook's MCP server — treat it as not-yet-usable rather than building a flow around it.
+
+**Git Sync now configures at the site level, and that's the default to reach for.** One connection (one repo, one branch) covers the whole site; `docs.yaml` maps each space to its own directory, which is the same shape this skill already scaffolds a monorepo into. Per-space Git Sync still exists, but it's now the exception — reach for it only when a specific space needs an independent repo or branch (e.g. a private space that can't live in the public docs repo).
 
 That means the cleanest end-to-end flow is always:
 
-1. Claude scaffolds a Git repo locally (and, when tooling permits, the remote)
+1. Claude scaffolds a Git repo locally as a monorepo (one directory per space), ideally with `docs.yaml` pre-authored mapping each space to its directory, and pushes the remote when tooling permits
 2. Claude creates the site, sections, and any empty spaces it can
-3. **The user does a short, well-scripted UI step in GitBook to wire each space to its directory in the repo**
+3. **The user does one short, well-scripted UI step in GitBook: connect the site to the repo/branch and confirm the space-to-directory mapping** — not one step per space
 4. Claude applies branding/customization
 
 The user's role in step 3 is unavoidable but should never be a surprise — generate clear, copy-paste-ready instructions for them. Reference: `references/git-sync-handoff.md`.
@@ -157,7 +159,8 @@ A few notes about this layout that often trip people up:
 - **`.gitbook.yaml` is optional.** GitBook works fine on the default convention of `README.md` + `SUMMARY.md` per space. Only add a `.gitbook.yaml` when you need to override the root, define redirects, or do something else non-default. The bundled example site (`references/example-site/`) has zero `.gitbook.yaml` files and works perfectly.
 - **`.gitbook/vars.yaml`** holds space-scoped variables that pages can reference inline (e.g. `support_email: support@evolve.com` referenced as `{% vars.support_email %}`). Useful for any value that appears on many pages.
 - **`.gitbook/includes/<name>.md`** holds reusable content blocks — a snippet you embed in many pages with `{% include "...persona-switcher" %}`. Use these instead of copy-pasting boilerplate.
-- The space directory name (e.g. `guides/`) is what the user enters into the "Project directory" field when wiring up Git Sync.
+- The space directory name (e.g. `guides/`) is what the user maps that space to under **Content mapping** when wiring up site-wide Git Sync — not the site's "Project directory" field, which only points at where `docs.yaml` itself lives (the repo root, in this layout). Don't conflate the two; see `references/git-sync-handoff.md`.
+- Consider pre-authoring a `docs.yaml` at the repo root that maps every space to its directory (see `references/git-sync-handoff.md` for the shape). GitBook reads it on first sync, so the user has less to fill in by hand during setup.
 
 A minimal `.gitbook.yaml`, when you do need one, looks like:
 
@@ -390,8 +393,8 @@ The steps below are described as outcomes, not endpoint calls — use whichever 
 1. **Verify access and find the org**: confirm the authenticated user, then list the orgs.
 2. **Create the site** with `{title, type, visibility, spaces?}`. **Default to Ultimate** (`type: "site"`; the plan tier is set on the site after creation or via the org's billing). Use `type: "basic"` (free) only when the user explicitly opts in. Don't include `spaces` if no spaces exist yet — you can add them later.
 3. **Decide how spaces will come into being.** Two paths:
-   - **Git-Sync-first (recommended)**: tell the user to create each space in the GitBook UI by clicking "Add new space" → "Sync to a GitHub or GitLab repository", picking the repo and the per-space project directory. This creates the space, sets up sync, and links it to the site in one action. The skill's job is to give exact, copyable instructions (one block per space). See `references/git-sync-handoff.md`.
-   - **Programmatic-first**: create empty spaces directly, add them to the site as site-spaces, and use content import or template application to load content. The user will still need to wire Git Sync in the UI later if they want bidirectional sync.
+   - **Site-wide Git Sync (recommended, default)**: tell the user to open **Git Sync** from the site sidebar once, connect the repo/branch, and map each space to its directory under **Content mapping**. This single UI pass creates/links every space to the site and wires up sync for all of them at once. The skill's job is to give exact, copyable instructions for that one pass. See `references/git-sync-handoff.md`.
+   - **Programmatic-first**: create empty spaces directly, add them to the site as site-spaces, and use content import or template application to load content. The user will still need to wire Git Sync in the UI later if they want bidirectional sync — and when they do, site-wide is still the default to point them at, not one space at a time.
 4. **Add sections** (multi-space sites with grouped navigation): a section is created by associating a space with a title and optional icon.
 5. **Resolve cross-space link sentinels**: if the scaffolded markdown contains `XSPACE_<KEY>` placeholders (which it should, for any link that crosses a space boundary), now is when you substitute them for the real space IDs returned by step 3 or 4. See `references/cross-space-links.md` for the substitution script. Commit and push the changes — the next Git Sync run picks them up.
 6. **Apply customization** (branding) — the full schema is broad: theme preset, colors (each as a `{light, dark}` themed pair), favicon, header (logo, primaryLink, links), footer (groups of links, copyright), themes (default light/dark, toggleable), AI mode, PDF export, and more. Recipes for common branding scenarios are in `references/customization-recipes.md`. Only change the fields you mean to — fetch the current settings first, modify in memory, and write the full result back rather than guessing at a partial payload.
@@ -406,7 +409,7 @@ What this means in practice:
 - **Don't scaffold per-language directories in the repo.** The Git repo has one space per topic, in English. The skill writes one set of markdown files per content area, full stop.
 - **Each section can hold many site-spaces.** A "Payments" section might contain `Payments` (en, git-synced), `Payments (FR)` (fr, computed), `Payments (DE)` (de, computed), etc. The structure response will list all of them; only the English ones need a Git Sync handoff.
 - **`localizedTitle` shows up everywhere.** Sections, section-groups, header links, footer links, and the site title itself all carry a `localizedTitle: {de: "...", fr: "...", ...}` map. When reading the customization, expect to see translations even for fields the user only set in English. Don't strip these out unless asked.
-- Auto-translation is a UI-only feature today. If the user wants it enabled on a section, surface that as part of the Git Sync handoff: "After Git Sync is configured, go to **Site → Sections → Payments → Translations** and enable the languages you want."
+- Auto-translation is a UI-only feature today. If the user wants it enabled on a section, surface that as part of the site-wide Git Sync handoff: "After Git Sync is configured, go to **Site → Sections → Payments → Translations** and enable the languages you want."
 
 When the user asks for "a docs site in five languages", the answer is one English content tree in Git plus auto-translation enabled per section in the UI — not five copies of the markdown.
 
@@ -433,7 +436,7 @@ Then make targeted changes rather than wholesale replacements. Don't replace who
 ### When to use content import vs. Git Sync
 
 - **Content import** is for ingesting external content (a website URL, a set of files) into a space. It's good for one-shot migrations from another doc tool.
-- **Git Sync** is for ongoing two-way sync between a Git repo and a space. This is what we're optimizing for in the standard flow.
+- **Git Sync** is for ongoing two-way sync between a Git repo and a site (or, as a fallback, an individual space). This is what we're optimizing for in the standard flow.
 - If the user has already-good content sitting outside both Git and GitBook (e.g. a Notion export), import it, then optionally turn on Git Sync afterward.
 
 ## Branding and customization
@@ -450,20 +453,21 @@ For a real example of the structure response (sections, section-groups, multi-la
 
 ## The Git Sync handoff
 
-This is the part that has to feel polished. Once the repo is pushed and the site exists, generate a clear set of per-space instructions. For each space, the user needs:
+This is the part that has to feel polished. Once the repo is pushed and the site exists, generate one clear handoff for the whole site — not one block per space. The user needs:
 
-1. The repo URL
-2. The branch name (usually `main`)
-3. The **project directory** for that space (e.g. `guides`, `api-reference`)
-4. The initial sync direction — almost always **GitHub → GitBook** (or GitLab → GitBook), since the repo is the source of truth at this point
+1. The repo URL and branch name (usually `main`)
+2. The site's **Project directory** — where `docs.yaml` lives (blank/root unless this is a larger monorepo)
+3. The initial sync direction — almost always **GitHub → GitBook** (or GitLab → GitBook), since the repo is the source of truth at this point
+4. The **content mapping** — each space's title paired with its directory (e.g. `Guides` → `./guides`, `API Reference` → `./api-reference`)
 
-`references/git-sync-handoff.md` has a template you can fill in and present to the user. Render it as a numbered list per space, not as one big wall of prose. After they finish, ask them to confirm — at that point you can check each space's sync state programmatically to verify.
+`references/git-sync-handoff.md` has a template you can fill in and present to the user: connect once, map every space in the same pass. Render it as a single numbered list, not a wall of prose, and not repeated per space. Only add a second handoff block if a specific space needs to be pulled out into its own independent repo/branch — see "When a space needs its own repo or branch" in that file. After the user finishes, ask them to confirm — at that point you can check each space's sync state programmatically to verify (there's no site-level status endpoint yet, so this is still a per-space check under the hood).
 
 ## Common mistakes to avoid
 
 - **Don't put the PAT in any file Claude writes.** Always read it from the environment.
 - **Don't silently swap the content source.** If the repo or folder the user named can't be read (remember: private repos return 404, same as nonexistent ones), stop and ask — never proceed with a lookalike public repo. See "Verify the content source before building."
-- **Don't try to set up Git Sync programmatically.** It's UI-only regardless of transport — always route through the UI handoff.
+- **Don't try to set up Git Sync programmatically.** It's UI-only regardless of transport — always route through the UI handoff. (`installGitSyncProviderOnTarget` exists in the API but doesn't remove the OAuth step and isn't yet exposed via MCP — don't route around the handoff because it looks tempting.)
+- **Don't hand off Git Sync one space at a time.** Site-wide Git Sync is the default — one connection, one content-mapping pass for every space. Fall back to per-space Git Sync only when a specific space needs an independent repo or branch.
 - **Don't paste an entire customization payload from memory.** Fetch the current state, modify it, then write the full result back. Schemas evolve and you'll write fewer bugs this way.
 - **Don't create a space for every section of content.** A space is a heavy unit (it has its own URL slug, sync, settings). Pages and folders within a space are the right tool for sub-grouping.
 - **Don't skip the structure-plan-and-confirm step**, even when the user is in a hurry. Restructuring a published site is painful.
@@ -477,7 +481,7 @@ This is the part that has to feel polished. Once the repo is pushed and the site
 - `references/migration-from-other-platforms.md` — pre-flight, source-platform mappings (Mintlify, Docusaurus, GitBook v1, RTD), anchor-pages strategy, format-pass, internal-link sweep. **Read this before any migration build, not after.**
 - `references/block-ecosystem.md` — which GitBook block to reach for in which content situation, with a decision table and worked examples (Updates, Mermaid, OpenAPI auto-gen, layout flags, card-tables, conditional content, includes, vars). **Read this before generating any non-trivial page.**
 - `references/cross-space-links.md` — the sentinel-and-resolve workflow for cross-space links in markdown, with a working substitution script
-- `references/git-sync-handoff.md` — the template for the user-facing Git Sync setup instructions
+- `references/git-sync-handoff.md` — the template for the user-facing Git Sync setup instructions, site-wide first with per-space as the documented fallback
 - `references/customization-recipes.md` — worked branding payloads for common scenarios
 - `references/example-site/` — a pruned snapshot (~150 files) of a real production-style GitBook site repo (markdown, `SUMMARY.md`s, `.gitbook/` configs). Read `PRUNE-NOTES.md` inside it first — it explains what's kept, what's dropped, and lists high-signal files for specific patterns.
 - `references/example-site/customization.json` — the customization export from that site, illustrating a complete real-world branding payload

--- a/skills/configure-site/references/api-cheatsheet.md
+++ b/skills/configure-site/references/api-cheatsheet.md
@@ -105,9 +105,9 @@ curl -s -H "Authorization: Bearer $GITBOOK_TOKEN" \
   https://api.gitbook.com/v1/spaces/$SPACE_ID/git/info
 ```
 
-Returns `{repoName, installationProvider: "github" | "gitlab", integration, url, updatedAt}` when sync is set up; 404 when not. Use this to verify the user finished the UI handoff.
+Returns `{repoName, installationProvider: "github" | "gitlab", integration, url, updatedAt}` when sync is set up; 404 when not. Use this to verify the user finished the UI handoff. There's no equivalent site-level status endpoint yet — verify a site-wide setup by checking each of its spaces this way.
 
-**There is no API to *set up* Git Sync.** This is the load-bearing constraint of this whole workflow.
+**There is effectively no API to *set up* Git Sync yet.** This is the load-bearing constraint of this whole workflow. There is an operation, `installGitSyncProviderOnTarget`, that accepts either a site or a space as its target — but connecting the GitHub/GitLab account still requires OAuth in the GitBook app, and as of this writing the operation isn't exposed through the GitBook MCP server (`search` for it returns nothing). GitBook is exploring a reusable "connection" that could be set up once and driven by API afterward, but that isn't available yet. Don't design a flow around it — always route Git Sync setup through the UI handoff (`references/git-sync-handoff.md`), and re-check `search`/`describe_operation` occasionally if you want to confirm whether this has changed.
 
 ## Site sections, section groups, and site-spaces
 

--- a/skills/configure-site/references/git-sync-handoff.md
+++ b/skills/configure-site/references/git-sync-handoff.md
@@ -1,20 +1,45 @@
 # Git Sync handoff
 
-GitBook's API does not let you set up Git Sync — the GitHub/GitLab app installation, repo selection, branch selection, project directory, and initial sync direction are all UI-only. This file is the template for the user-facing instructions you generate so the user can finish wiring it up themselves.
+Git Sync can now be configured for an entire **site** in one pass, mapping every space to a directory in a single repo/branch via `docs.yaml`. **This is the default workflow — always reach for site-wide Git Sync first.** Per-space ("individual space") Git Sync still exists, but treat it as a fallback for the specific case where one space needs to live in a different repo or branch than the rest of the site (e.g. a private space, or content that must stay out of the public docs repo).
 
-The goal: hand the user a numbered, copy-paste-ready set of steps. One block per space. No prose paragraphs they'd have to read carefully — they should be able to skim it.
+GitBook's API does not let you fully self-serve this setup yet: connecting the GitHub/GitLab account (OAuth), picking the repository, and choosing the branch and initial sync direction are UI-only. There is an API operation, `installGitSyncProviderOnTarget`, that accepts either a site or a space as its target — but as of this writing it isn't exposed through the GitBook MCP server, and the account-connection step still has to happen in the app first regardless. GitBook has said they're exploring letting a connection be set up once and reused across the API, but that isn't available yet. Don't build a flow around it — check `search`/`describe_operation` for `installGitSyncProviderOnTarget` if you want to confirm current availability, but default to the UI handoff below.
+
+This file is the template for the user-facing instructions you generate so the user can finish wiring it up themselves.
 
 ## Pre-handoff checklist
 
 Before generating the handoff, make sure all of this is true:
 
 - The local repo is committed and pushed to a remote (GitHub or GitLab).
-- You know each space's project directory in the repo (e.g. `guides`, `api-reference`).
+- You know the site's **Project directory** — the path in the repo where `docs.yaml` should live. Leave this blank for a repo root; set it only when the docs live in a subdirectory of a larger monorepo (e.g. alongside application code).
+- You know each space's **content directory** — the path (relative to the project directory, or from the repo root with a leading `/`) that maps to that space. This is what you'd pre-author into `docs.yaml` if you scaffolded the repo yourself; see `content-configuration.md` conventions below.
 - You know which branch the user wants to sync from (default: `main`).
 - The site exists in GitBook (you have its dashboard URL).
-- For each space, you know whether it already exists (and you have its URL) or whether the user will create it during this step.
+- You know whether the repo content should overwrite GitBook (repo is the source of truth — the normal case for a fresh scaffold) or whether GitBook's existing content should overwrite the repo.
 
 If any of those is false, finish that prep work first. Don't ask the user to context-switch into the GitBook UI before everything is ready.
+
+**If you scaffolded the repo yourself**, pre-author `docs.yaml` at the project directory with each space already mapped (see the example below) and commit/push it before handoff. GitBook reads the existing mapping on first sync, so the user has less to fill in by hand during **Map your spaces**. Verify the mapping still matches what you tell them to enter in the UI — GitBook creates or updates `docs.yaml` when it saves the content mapping, so the two need to agree.
+
+```yaml
+# docs.yaml, at the project directory (repo root if unset)
+$schema: https://api.gitbook.com/openapi.yaml#/components/schemas/GitSyncSiteConfig
+site:
+  title: [Site title]
+  structure:
+    - type: space
+      key: guides
+      title: Guides
+      path: guides
+      content:
+        directory: ./guides
+    - type: space
+      key: api-reference
+      title: API Reference
+      path: api-reference
+      content:
+        directory: ./api-reference
+```
 
 ## The handoff template
 
@@ -24,45 +49,40 @@ Fill in the bracketed values and present this to the user:
 
 > ## Setting up Git Sync — one short step in the GitBook UI
 >
-> Everything else is done. To finish, you need to wire up two-way sync between each space and the corresponding folder in your repo. This is the one part that GitBook's API doesn't expose, so it has to happen in the UI. It takes about 30 seconds per space.
+> Everything else is done. To finish, you need to connect the site to your repo and confirm which directory maps to which space. This is the one part that GitBook's API doesn't expose, so it has to happen in the UI. It takes about a minute for the whole site — you don't need to repeat this per space.
 >
-> **Before you start:** if you haven't already, install the GitBook app on your GitHub/GitLab account. The first space you wire up will prompt you to do this.
+> ### Open Git Sync for the site
 >
-> ---
+> 1. Open the site dashboard: **[https://app.gitbook.com/o/<orgId>/sites/<siteId>](https://app.gitbook.com/...)**
+> 2. Open **Git Sync** in the sidebar.
+> 3. Connect **[GitHub / GitLab]**.
+>    - **GitHub**: authorize the GitBook app if prompted. If you hit a "potential duplicated accounts" error, that means your GitHub account is already linked to a different GitBook user — log out and sign in with GitHub directly to find which account, then unlink it in Settings before retrying.
+>    - **GitLab**: create a Personal access token in GitLab (user settings → Access tokens) with the `api`, `read_repository`, and `write_repository` scopes, then paste it in. If the token has a role, use `Maintainer` or `Admin`.
+> 4. Under **Source repository**, select **`[owner/repo]`** and branch **`[main]`**. If the branch doesn't exist yet, GitBook creates it on first sync.
+> 5. Choose the initial sync direction: **[GitHub/GitLab → GitBook]**, since the repo is the source of truth. *(Only pick "Swap direction" if GitBook's existing content should overwrite the repo instead — double-check before confirming, this isn't easily undone.)*
+> 6. Click **Show advanced options** and set **Project directory** to **`[repo root, or subdirectory if this is a monorepo]`**.
+> 7. Under **Content mapping**, map each space to its directory:
+>    - **`[Space 1 Title]`** → **`[./guides]`**
+>    - **`[Space 2 Title]`** → **`[./api-reference]`**
+>    - *(repeat for each space)*
+> 8. Click **Sync** and wait for the import to finish.
 >
-> ### Space 1: `[Space Title]`
->
-> 1. Open the space dashboard: **[https://app.gitbook.com/o/<orgId>/s/<spaceId>](https://app.gitbook.com/...)**
-> 2. Click **Set up Git Sync** in the top-right.
-> 3. Choose **GitHub** (or GitLab — pick whichever matches your repo).
-> 4. Authorize GitBook if prompted, then select repository: **`[owner/repo]`**
-> 5. Branch: **`main`**
-> 6. Click **Show advanced options** and set **Project directory** to: **`[guides]`**
-> 7. Initial sync direction: **GitHub → GitBook** (since the repo is the source of truth).
-> 8. Click **Initialize** and wait for the import to finish.
->
-> ### Space 2: `[Space Title]`
->
-> 1. Open the space dashboard: **[https://app.gitbook.com/o/<orgId>/s/<spaceId>](https://app.gitbook.com/...)**
-> 2. Click **Set up Git Sync** in the top-right.
-> 3. Choose **GitHub**.
-> 4. Repository: **`[owner/repo]`**
-> 5. Branch: **`main`**
-> 6. **Project directory**: **`[api-reference]`**
-> 7. Initial sync direction: **GitHub → GitBook**.
-> 8. Click **Initialize**.
->
-> *(repeat for each remaining space)*
->
-> ---
->
-> Once you've done all of them, let me know and I'll verify each space's sync state and apply the branding settings.
+> Once you've done this, let me know and I'll verify the site's sync state and apply the branding settings.
 
 ---
 
+## When a space needs its own repo or branch
+
+Use individual space Git Sync only when one space genuinely can't share the site's repo/branch — for example, a private space that must stay out of the public docs repo. Two ways in:
+
+- **Excluding a space already in site-wide Git Sync**: in the site's Git Sync content mapping, click the remove icon next to that space. GitBook then asks whether to (a) point it at the site's own repo/branch (adds it back into site-wide sync) or (b) point it at an independent repo/branch (space-level sync).
+- **A space that was never part of site-wide sync**: in that space, click **Set up** next to **Git Sync** in the space header, then choose **GitHub Sync** or **GitLab Sync** from the provider list and follow the same connect → select repo/branch → direction → project directory steps, scoped to just that space.
+
+Don't default to this path — it fragments where content lives and each space then needs its own handoff and verification. Reach for it only when the user has a concrete reason a space can't share the site's repo.
+
 ## Verifying afterwards
 
-After the user confirms they're done, verify each space programmatically:
+After the user confirms they're done, verify each space programmatically (there's no site-level Git Sync status endpoint yet — check per space):
 
 ```bash
 for space_id in $SPACE_IDS; do
@@ -76,14 +96,17 @@ For each space, expect a 200 with `{repoName, installationProvider, integration,
 
 Common issues:
 
-- **"Repository not found"** in the UI — the GitBook app doesn't have access. The user needs to go to GitHub Settings → Applications → GitBook → Configure and grant access to the right repo.
-- **Initial sync direction wrong** — if the user picks "GitBook → GitHub" by mistake on a space whose content lives in the repo, GitBook will overwrite the repo with the empty space. They can't undo this except by `git revert`. Be very explicit in the instructions about direction.
-- **Project directory missing or wrong** — the space will sync the wrong content (or the whole repo). They can edit this in space settings → Git after the fact.
-
-## When the user wants GitLab instead of GitHub
-
-The flow is identical except the user needs to generate a GitLab personal access token first with `api`, `read_repository`, `write_repository` scopes, and they'll be asked to paste it in the GitBook UI. Mention this in the handoff if the repo is on GitLab.
+- **"Repository not found"** in the UI — the GitBook app doesn't have access. For GitHub: Settings → Applications → GitBook → Configure, and grant access to the right repo. For GitLab: confirm the access token has `api`, `read_repository`, `write_repository`.
+- **Initial sync direction wrong** — if the user picks "GitBook → GitHub/GitLab" by mistake when the repo's content should have won, GitBook will overwrite the repo with GitBook's (possibly empty) content. They can't undo this except by `git revert`. Be very explicit in the instructions about direction.
+- **Project directory vs. content mapping confusion** — the site's **Project directory** is only where `docs.yaml` lives; each space's actual content directory is set separately in **Content mapping**. Getting these swapped is the most common setup mistake with the new site-wide flow. They can fix the mapping afterward in the site's Git Sync settings, which rewrites `docs.yaml`.
+- **Protected branch push errors** — the GitBook app needs to bypass branch protection rules to push. On GitHub: repo settings → branch protection → allow `gitbook-com` to bypass. On GitLab: if `main` is protected, sync from a separate branch and merge that into `main` manually.
 
 ## When there is no remote (local-only)
 
 Git Sync requires a hosted remote — GitBook reaches the repo over the public Git provider APIs, not via direct file access. If the user explicitly chose local-only, they'll need to either push to a hosted remote later (GitBook supports private repos) or skip Git Sync and use the API content path. Tell them this clearly rather than implying Git Sync is possible without a remote.
+
+## Other things worth mentioning in the handoff
+
+- **PR previews (GitHub only)**: once Git Sync is set up, PRs against the synced branch automatically get a status check with a preview link, as long as the GitBook GitHub app has read access to PRs. Previews are skipped by default for PRs from forks (a security default, configurable in Git Sync settings) and aren't available on sites behind authenticated access.
+- **Enterprise IP allowlisting**: if the user's network restricts outbound traffic, they'll need to allow these five IPs: `34.136.22.210`, `34.29.189.57`, `35.223.181.150`, `34.72.115.112`, `136.116.236.109`.
+- **Commit messages**: GitBook's default export commit message is `GITBOOK-<num>: <change request subject>`. This is customizable in the Git Sync advanced options — mention it if the user has commit message conventions to follow.

--- a/skills/write-docs/references/configuration.md
+++ b/skills/write-docs/references/configuration.md
@@ -42,7 +42,10 @@ For repositories with multiple documentation projects:
       SUMMARY.md
 ```
 
-When setting up Git Sync, configure the "Project directory" to point to the subdirectory containing the `.gitbook.yaml` file.
+How you point Git Sync at this subdirectory depends on the sync scope:
+
+* **Site-wide Git Sync (default)** — the site's "Project directory" points to where `docs.yaml` lives, not to any individual space's `.gitbook.yaml`. Each space's directory (containing its own `.gitbook.yaml`) is set separately via `docs.yaml`'s content mapping. See `configure-site`'s `references/git-sync-handoff.md`.
+* **Per-space Git Sync** (used only when a space needs an independent repo/branch) — that space's own "Project directory" field points directly at the subdirectory containing its `.gitbook.yaml`.
 
 **Important notes:**
 


### PR DESCRIPTION
Git Sync can now be configured once for an entire site (repo/branch + docs.yaml content mapping), so the configure-site skill's UI handoff, API cheatsheet, and write-docs config reference now recommend that path first and treat per-space Git Sync as the fallback for a space needing an independent repo/branch. Also notes the new installGitSyncProviderOnTarget API operation, which still requires OAuth in the app and isn't yet exposed via GitBook's MCP server.