### PR TITLE
Rename docs.yaml to gitbook-docs.yaml, fix false-failure in publish-skill PR step

### DIFF
--- a/.github/workflows/publish-skill.yml
+++ b/.github/workflows/publish-skill.yml
@@ -66,13 +66,18 @@ jobs:
           GH_TOKEN: ${{ secrets.PUBLIC_DOCS_PAT }}
           GITHUB_SHA: ${{ github.sha }}
         run: |
-          set -euo pipefail
-          if ! gh pr view sync/gitbook-skill --repo GitbookIO/public-docs >/dev/null 2>&1; then
-            gh pr create --repo GitbookIO/public-docs \
-              --head sync/gitbook-skill \
-              --base main \
-              --title "Sync gitbook skill.md from gitbook-skills" \
-              --body "Auto-generated from https://github.com/GitbookIO/gitbook-skills/commit/${GITHUB_SHA}. This PR is kept up to date automatically — new merges to gitbook-skills main will overwrite it until it's merged."
-          else
-            echo "PR already open on sync/gitbook-skill, updated in place by the force-push above"
+          set -uo pipefail
+          output=$(gh pr create --repo GitbookIO/public-docs \
+            --head sync/gitbook-skill \
+            --base main \
+            --title "Sync gitbook skill.md from gitbook-skills" \
+            --body "Auto-generated from https://github.com/GitbookIO/gitbook-skills/commit/${GITHUB_SHA}. This PR is kept up to date automatically — new merges to gitbook-skills main will overwrite it until it's merged." 2>&1)
+          status=$?
+          echo "$output"
+          if [ "$status" -ne 0 ]; then
+            if echo "$output" | grep -qi "already exists"; then
+              echo "PR already open on sync/gitbook-skill, updated in place by the force-push above"
+            else
+              exit "$status"
+            fi
           fi

--- a/skills/configure-site/SKILL.md
+++ b/skills/configure-site/SKILL.md
@@ -2,7 +2,7 @@
 name: configure-site
 metadata:
   version: "1.0"
-description: "Create and maintain entire GitBook documentation sites end-to-end — design the site structure from source content, scaffold a Git repository in monorepo layout, set up the GitHub/GitLab remote, drive the GitBook API (via its REST API or MCP server) to create the site/sections/spaces, apply branded customization, and hand the user clean instructions for the one UI step (Git Sync wiring) that GitBook does not expose programmatically. Always set up Git Sync at the site level first — mapping every space to a directory in one repo/branch via docs.yaml — and only fall back to per-space Git Sync when one space genuinely needs an independent repo or branch. Trigger this skill whenever the user wants to spin up a new GitBook docs site, restructure or extend an existing one, link a site or spaces to a Git repo for sync, change a site's branding (logo, colors, fonts, header/footer), or programmatically manage spaces, sections, or site-spaces. This skill is the orchestration layer; for authoring the markdown content of any individual page it defers to the companion `write-docs` skill."
+description: "Create and maintain entire GitBook documentation sites end-to-end — design the site structure from source content, scaffold a Git repository in monorepo layout, set up the GitHub/GitLab remote, drive the GitBook API (via its REST API or MCP server) to create the site/sections/spaces, apply branded customization, and hand the user clean instructions for the one UI step (Git Sync wiring) that GitBook does not expose programmatically. Always set up Git Sync at the site level first — mapping every space to a directory in one repo/branch via gitbook-docs.yaml — and only fall back to per-space Git Sync when one space genuinely needs an independent repo or branch. Trigger this skill whenever the user wants to spin up a new GitBook docs site, restructure or extend an existing one, link a site or spaces to a Git repo for sync, change a site's branding (logo, colors, fonts, header/footer), or programmatically manage spaces, sections, or site-spaces. This skill is the orchestration layer; for authoring the markdown content of any individual page it defers to the companion `write-docs` skill."
 ---
 
 # Configure GitBook Site
@@ -39,11 +39,11 @@ Never write the token to a file, never echo it back in a response, never commit 
 
 The most important thing to internalize before doing anything: **GitBook can do almost everything except set up Git Sync, regardless of transport**. Authorizing GitHub/GitLab, picking the repository, choosing the branch, and choosing the initial sync direction are all UI-only operations — both the REST API and MCP (which wraps it) only let you *read* the resulting Git Sync state, never set it up. There's an API operation, `installGitSyncProviderOnTarget`, that targets either a site or a space, but the account-connection (OAuth) step still has to happen in the app, and it isn't yet exposed through GitBook's MCP server — treat it as not-yet-usable rather than building a flow around it.
 
-**Git Sync now configures at the site level, and that's the default to reach for.** One connection (one repo, one branch) covers the whole site; `docs.yaml` maps each space to its own directory, which is the same shape this skill already scaffolds a monorepo into. Per-space Git Sync still exists, but it's now the exception — reach for it only when a specific space needs an independent repo or branch (e.g. a private space that can't live in the public docs repo).
+**Git Sync now configures at the site level, and that's the default to reach for.** One connection (one repo, one branch) covers the whole site; `gitbook-docs.yaml` maps each space to its own directory, which is the same shape this skill already scaffolds a monorepo into. Per-space Git Sync still exists, but it's now the exception — reach for it only when a specific space needs an independent repo or branch (e.g. a private space that can't live in the public docs repo).
 
 That means the cleanest end-to-end flow is always:
 
-1. Claude scaffolds a Git repo locally as a monorepo (one directory per space), ideally with `docs.yaml` pre-authored mapping each space to its directory, and pushes the remote when tooling permits
+1. Claude scaffolds a Git repo locally as a monorepo (one directory per space), ideally with `gitbook-docs.yaml` pre-authored mapping each space to its directory, and pushes the remote when tooling permits
 2. Claude creates the site, sections, and any empty spaces it can
 3. **The user does one short, well-scripted UI step in GitBook: connect the site to the repo/branch and confirm the space-to-directory mapping** — not one step per space
 4. Claude applies branding/customization
@@ -159,8 +159,8 @@ A few notes about this layout that often trip people up:
 - **`.gitbook.yaml` is optional.** GitBook works fine on the default convention of `README.md` + `SUMMARY.md` per space. Only add a `.gitbook.yaml` when you need to override the root, define redirects, or do something else non-default. The bundled example site (`references/example-site/`) has zero `.gitbook.yaml` files and works perfectly.
 - **`.gitbook/vars.yaml`** holds space-scoped variables that pages can reference inline (e.g. `support_email: support@evolve.com` referenced as `{% vars.support_email %}`). Useful for any value that appears on many pages.
 - **`.gitbook/includes/<name>.md`** holds reusable content blocks — a snippet you embed in many pages with `{% include "...persona-switcher" %}`. Use these instead of copy-pasting boilerplate.
-- The space directory name (e.g. `guides/`) is what the user maps that space to under **Content mapping** when wiring up site-wide Git Sync — not the site's "Project directory" field, which only points at where `docs.yaml` itself lives (the repo root, in this layout). Don't conflate the two; see `references/git-sync-handoff.md`.
-- Consider pre-authoring a `docs.yaml` at the repo root that maps every space to its directory (see `references/git-sync-handoff.md` for the shape). GitBook reads it on first sync, so the user has less to fill in by hand during setup.
+- The space directory name (e.g. `guides/`) is what the user maps that space to under **Content mapping** when wiring up site-wide Git Sync — not the site's "Project directory" field, which only points at where `gitbook-docs.yaml` itself lives (the repo root, in this layout). Don't conflate the two; see `references/git-sync-handoff.md`.
+- Consider pre-authoring a `gitbook-docs.yaml` at the repo root that maps every space to its directory (see `references/git-sync-handoff.md` for the shape). GitBook reads it on first sync, so the user has less to fill in by hand during setup.
 
 A minimal `.gitbook.yaml`, when you do need one, looks like:
 
@@ -456,7 +456,7 @@ For a real example of the structure response (sections, section-groups, multi-la
 This is the part that has to feel polished. Once the repo is pushed and the site exists, generate one clear handoff for the whole site — not one block per space. The user needs:
 
 1. The repo URL and branch name (usually `main`)
-2. The site's **Project directory** — where `docs.yaml` lives (blank/root unless this is a larger monorepo)
+2. The site's **Project directory** — where `gitbook-docs.yaml` lives (blank/root unless this is a larger monorepo)
 3. The initial sync direction — almost always **GitHub → GitBook** (or GitLab → GitBook), since the repo is the source of truth at this point
 4. The **content mapping** — each space's title paired with its directory (e.g. `Guides` → `./guides`, `API Reference` → `./api-reference`)
 

--- a/skills/configure-site/references/git-sync-handoff.md
+++ b/skills/configure-site/references/git-sync-handoff.md
@@ -1,6 +1,6 @@
 # Git Sync handoff
 
-Git Sync can now be configured for an entire **site** in one pass, mapping every space to a directory in a single repo/branch via `docs.yaml`. **This is the default workflow — always reach for site-wide Git Sync first.** Per-space ("individual space") Git Sync still exists, but treat it as a fallback for the specific case where one space needs to live in a different repo or branch than the rest of the site (e.g. a private space, or content that must stay out of the public docs repo).
+Git Sync can now be configured for an entire **site** in one pass, mapping every space to a directory in a single repo/branch via `gitbook-docs.yaml`. **This is the default workflow — always reach for site-wide Git Sync first.** Per-space ("individual space") Git Sync still exists, but treat it as a fallback for the specific case where one space needs to live in a different repo or branch than the rest of the site (e.g. a private space, or content that must stay out of the public docs repo).
 
 GitBook's API does not let you fully self-serve this setup yet: connecting the GitHub/GitLab account (OAuth), picking the repository, and choosing the branch and initial sync direction are UI-only. There is an API operation, `installGitSyncProviderOnTarget`, that accepts either a site or a space as its target — but as of this writing it isn't exposed through the GitBook MCP server, and the account-connection step still has to happen in the app first regardless. GitBook has said they're exploring letting a connection be set up once and reused across the API, but that isn't available yet. Don't build a flow around it — check `search`/`describe_operation` for `installGitSyncProviderOnTarget` if you want to confirm current availability, but default to the UI handoff below.
 
@@ -11,18 +11,18 @@ This file is the template for the user-facing instructions you generate so the u
 Before generating the handoff, make sure all of this is true:
 
 - The local repo is committed and pushed to a remote (GitHub or GitLab).
-- You know the site's **Project directory** — the path in the repo where `docs.yaml` should live. Leave this blank for a repo root; set it only when the docs live in a subdirectory of a larger monorepo (e.g. alongside application code).
-- You know each space's **content directory** — the path (relative to the project directory, or from the repo root with a leading `/`) that maps to that space. This is what you'd pre-author into `docs.yaml` if you scaffolded the repo yourself; see `content-configuration.md` conventions below.
+- You know the site's **Project directory** — the path in the repo where `gitbook-docs.yaml` should live. Leave this blank for a repo root; set it only when the docs live in a subdirectory of a larger monorepo (e.g. alongside application code).
+- You know each space's **content directory** — the path (relative to the project directory, or from the repo root with a leading `/`) that maps to that space. This is what you'd pre-author into `gitbook-docs.yaml` if you scaffolded the repo yourself; see `content-configuration.md` conventions below.
 - You know which branch the user wants to sync from (default: `main`).
 - The site exists in GitBook (you have its dashboard URL).
 - You know whether the repo content should overwrite GitBook (repo is the source of truth — the normal case for a fresh scaffold) or whether GitBook's existing content should overwrite the repo.
 
 If any of those is false, finish that prep work first. Don't ask the user to context-switch into the GitBook UI before everything is ready.
 
-**If you scaffolded the repo yourself**, pre-author `docs.yaml` at the project directory with each space already mapped (see the example below) and commit/push it before handoff. GitBook reads the existing mapping on first sync, so the user has less to fill in by hand during **Map your spaces**. Verify the mapping still matches what you tell them to enter in the UI — GitBook creates or updates `docs.yaml` when it saves the content mapping, so the two need to agree.
+**If you scaffolded the repo yourself**, pre-author `gitbook-docs.yaml` at the project directory with each space already mapped (see the example below) and commit/push it before handoff. GitBook reads the existing mapping on first sync, so the user has less to fill in by hand during **Map your spaces**. Verify the mapping still matches what you tell them to enter in the UI — GitBook creates or updates `gitbook-docs.yaml` when it saves the content mapping, so the two need to agree.
 
 ```yaml
-# docs.yaml, at the project directory (repo root if unset)
+# gitbook-docs.yaml, at the project directory (repo root if unset)
 $schema: https://api.gitbook.com/openapi.yaml#/components/schemas/GitSyncSiteConfig
 site:
   title: [Site title]
@@ -98,7 +98,7 @@ Common issues:
 
 - **"Repository not found"** in the UI — the GitBook app doesn't have access. For GitHub: Settings → Applications → GitBook → Configure, and grant access to the right repo. For GitLab: confirm the access token has `api`, `read_repository`, `write_repository`.
 - **Initial sync direction wrong** — if the user picks "GitBook → GitHub/GitLab" by mistake when the repo's content should have won, GitBook will overwrite the repo with GitBook's (possibly empty) content. They can't undo this except by `git revert`. Be very explicit in the instructions about direction.
-- **Project directory vs. content mapping confusion** — the site's **Project directory** is only where `docs.yaml` lives; each space's actual content directory is set separately in **Content mapping**. Getting these swapped is the most common setup mistake with the new site-wide flow. They can fix the mapping afterward in the site's Git Sync settings, which rewrites `docs.yaml`.
+- **Project directory vs. content mapping confusion** — the site's **Project directory** is only where `gitbook-docs.yaml` lives; each space's actual content directory is set separately in **Content mapping**. Getting these swapped is the most common setup mistake with the new site-wide flow. They can fix the mapping afterward in the site's Git Sync settings, which rewrites `gitbook-docs.yaml`.
 - **Protected branch push errors** — the GitBook app needs to bypass branch protection rules to push. On GitHub: repo settings → branch protection → allow `gitbook-com` to bypass. On GitLab: if `main` is protected, sync from a separate branch and merge that into `main` manually.
 
 ## When there is no remote (local-only)

--- a/skills/write-docs/references/configuration.md
+++ b/skills/write-docs/references/configuration.md
@@ -44,7 +44,7 @@ For repositories with multiple documentation projects:
 
 How you point Git Sync at this subdirectory depends on the sync scope:
 
-* **Site-wide Git Sync (default)** — the site's "Project directory" points to where `docs.yaml` lives, not to any individual space's `.gitbook.yaml`. Each space's directory (containing its own `.gitbook.yaml`) is set separately via `docs.yaml`'s content mapping. See `configure-site`'s `references/git-sync-handoff.md`.
+* **Site-wide Git Sync (default)** — the site's "Project directory" points to where `gitbook-docs.yaml` lives, not to any individual space's `.gitbook.yaml`. Each space's directory (containing its own `.gitbook.yaml`) is set separately via `gitbook-docs.yaml`'s content mapping. See `configure-site`'s `references/git-sync-handoff.md`.
 * **Per-space Git Sync** (used only when a space needs an independent repo/branch) — that space's own "Project directory" field points directly at the subdirectory containing its `.gitbook.yaml`.
 
 **Important notes:**


### PR DESCRIPTION
The site-centric Git Sync config file at the repo root is actually named gitbook-docs.yaml, not docs.yaml (https://gitbook.com/docs/docs-as-code/git-sync). Update all skill references accordingly.

Also fix publish-skill.yml's "Open PR if needed" step, which was going red whenever the PR already existed even though the branch had already been pushed successfully. It used to pre-check with `gh pr view` and only call `gh pr create` when that looked like no PR existed; a false negative there made `gh pr create` blow up with "pull request already exists" and fail the whole job. Now it just calls `gh pr create` directly and treats an "already exists" error as the expected, successful case.